### PR TITLE
Fix support forum link and hide feedback script

### DIFF
--- a/app/views/sugar_pond/support/index.html.erb
+++ b/app/views/sugar_pond/support/index.html.erb
@@ -1,59 +1,10 @@
-<style media='all' type='text/css'>
-div#gsfn_list_widget img { border: none; }
-div#gsfn_list_widget { font-size: 12px; width: 15em; border: 0.5em solid #bad032; background-color: #fff; padding: 0.5em; margin-right: -17em; float: right; }
-div#gsfn_list_widget a.widget_title { color: #000; display: block; margin-bottom: 10px; font-weight: bold; }
-div#gsfn_list_widget .powered_by { margin-top: 8px; padding-top: 8px; border-top: 1px solid #DDD; }
-div#gsfn_list_widget .powered_by a { color: #333; font-size: 90%; }
-div#gsfn_list_widget div#gsfn_content { }
-div#gsfn_list_widget div#gsfn_content li { text-align:left; margin-bottom:6px; }
-div#gsfn_list_widget div#gsfn_content a.gsfn_link { line-height: 1; }
-div#gsfn_list_widget div#gsfn_content span.time { font-size: 90%; padding-left: 3px; }
-div#gsfn_list_widget div#gsfn_content p.gsfn_summary { margin-top: 2px }
-</style>
-
 <h1>Support</h1>
 
 <div class="propertypage">
   <h2>Problems?  Ideas?  Questions?  We're here to help.</h2>
   
     <p>You can talk to us via 
-	  <%= link_to "our community support forum", "http://getsatisfaction.com/sugarpond" %>, 
-	  powered by Get Satisfaction. 
-	  There, you'll be able to ask a
-	  question and get responses not only from our staff, but also other users.  (You can also post
-	  questions privately if you wish.)</p>
-	  
-	  <p>To get in touch with us via the forum, please use the form below.</p>
-	  
-  <div style="max-width: 44em;">	  
-	  
-		<!--
-		Disabled for now, pending http://getsatisfaction.com/getsatisfaction/topics/cannot_get_topics_widget_to_display_my_products_topics?utm_medium=email&utm_source=share
-		<div id='gsfn_list_widget'>
-		<a href="http://getsatisfaction.com/getsatisfaction" class="widget_title">People are talking about...</a>
-		<div id='gsfn_content'>Loading...</div>
-		<div class='powered_by'>
-		<a href="http://getsatisfaction.com/"><img alt="Favicon" src="http://www.getsatisfaction.com/favicon.gif" style="vertical-align: middle;" /></a>
-		<a href="http://getsatisfaction.com/">Get Satisfaction support network</a>
-		</div>
-		</div>
-		<script src="http://getsatisfaction.com/getsatisfaction/widgets/javascripts/8a8efe5504/widgets.js" type="text/javascript"></script>
-		<script src="http://getsatisfaction.com/getsatisfaction/topics.widget?callback=gsfnTopicsCallback&amp;length=80&amp;limit=5&amp;sort=recently_active&amp;product=journey_journey_surveys" type="text/javascript"></script>
-		-->
-		
-		  <script type="text/javascript" charset="utf-8">
-		  var is_ssl = ("https:" == document.location.protocol);
-		  var asset_host = is_ssl ? "https://s3.amazonaws.com/getsatisfaction.com/" : "http://s3.amazonaws.com/getsatisfaction.com/";
-		  document.write(unescape("%3Cscript src='" + asset_host + "javascripts/feedback-v2.js' type='text/javascript'%3E%3C/script%3E"));
-		</script>
-		
-		<script type="text/javascript" charset="utf-8">
-		  var feedback_widget_options = {};
-		  feedback_widget_options.display = "inline";  
-		  feedback_widget_options.company = "sugarpond";
-		  feedback_widget_options.style = "idea";
-		
-		  var feedback_widget = new GSFN.feedback_widget(feedback_widget_options);
-		</script>
-	</div>
+	  <%= link_to "our community support forum", "https://github.com/nbudin/journey/issues" %>,
+	  powered by GitHub. There, you'll be able to ask questions and respond to other users.</p>
+
 </div>


### PR DESCRIPTION
Hi Nat, I thought it might be useful to direct users towards the GitHub issues page rather than the old support forum which has been deleted. As a result, the contact form no longer works.

Also, `feedback_widget` appears to be unused entirely now, so I have removed the redundant javascript and CSS from the page.